### PR TITLE
Added persistent clipboard storage feature

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,18 @@
 {
 	"extends": "eslint-config-mlewand-node",
+	"parserOptions": {
+		"ecmaVersion": 8
+	},
 	"rules": {
 		"strict": 0,
-		"no-unused-vars": [  "error", { "argsIgnorePattern": "^_" } ]
+		"no-unused-vars": [  "error", { "argsIgnorePattern": "^_" } ],
+		"dot-notation": [
+			2,
+			{
+				"allowKeywords": true
+			}
+		],
+		"eol-last": "off"
 	},
 	"env": {
 		"node": true,

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+	"persistentStorage": true,
+	"maxSnapshots": 50
+}

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 					<button class="btn btn-success btn-xl" onclick="app.captureSnapshot()">Capture a snapshot</button>
 					<button class="btn btn-xl" onclick="app.openSnapshot()">Open</button>
 					<button class="btn btn-xl" onclick="app.saveSnapshot()">Save</button>
+					<button class="btn brn-error btn-xl" onclick="app.snapshots.remove( app.snapshots.getSelected() )">Remove selected</button>
 					<button class="btn btn-xl" onclick="app.writeSnapshot( app.snapshots.getSelected() );" data-toggle="tooltip" title="Write currently selected snapshot to your OS clipboard">Write</button>
 				</div>
 			</div>
@@ -47,8 +48,8 @@
 			const App = require( './src/App.js' );
 
 			let app = new App();
-			app.main();
 			window.app = app;
+			app.main();
 		} )();
 
 	</script>

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "electron-debug": "^1.4.0",
     "electron-rebuild": "^1.5.7",
     "fs-extra": "^4.0.2",
-    "iconv-lite": "^0.4.17",
     "jszip": "^3.1.5",
+    "localforage": "^1.5.5",
     "pad": "^1.1.0",
     "sanitize-filename": "^1.6.1",
     "win-clipboard": "^0.0.5"

--- a/package.json
+++ b/package.json
@@ -46,19 +46,11 @@
     "electron": "^1.3.3",
     "electron-packager": "^8.0.0",
     "electron-reload": "^1.2.2",
-    "eslint-config-mlewand-node": "^0.2.1",
+    "eslint-config-mlewand-node": "^0.2.2",
     "mocha": "^4.0.1",
     "mock-require": "^2.0.2",
     "object.entries": "^1.0.4",
     "sinon": "^4.1.2",
-    "sinon-chai": "^2.14.0",
-    "xo": "^0.16.0"
-  },
-  "xo": {
-    "esnext": true,
-    "envs": [
-      "node",
-      "browser"
-    ]
+    "sinon-chai": "^2.14.0"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -29,6 +29,11 @@ class App {
 		await this.snapshots.loadFromStorage();
 
 		this.snapshots.on( 'selected', item => {
+			if ( !item ) {
+				// #42.
+				return;
+			}
+
 			let firstType = item.getTypes().next().value;
 
 			if ( firstType ) {

--- a/src/App.js
+++ b/src/App.js
@@ -8,20 +8,25 @@ const Navigation = require( './Component/Navigation' ),
 	SnapshotList = require( './SnapshotsList' ),
 	path = require( 'path' ),
 	snapshotStorer = require( './SnapshotStorer' ),
+	Storage = require( './Storage' ),
 	notification = require( './notification' ),
 	electron = require( 'electron' );
 
 class App {
 	constructor() {
 		this.controller = new MainWindowController( this );
-		this.snapshots = new SnapshotList();
+		this.storage = new Storage();
+
+		this.snapshots = new SnapshotList( this.storage.snapshots );
 
 		this.nav = new Navigation( this.controller, this.snapshots );
 		this.types = new Types( this.controller, this.snapshots );
 		this.previews = new Previews( this.controller, this.snapshots );
 	}
 
-	main() {
+	async main() {
+		await this.snapshots.loadFromStorage();
+
 		this.snapshots.on( 'selected', item => {
 			let firstType = item.getTypes().next().value;
 
@@ -60,11 +65,14 @@ class App {
 	 */
 	openSnapshot( window ) {
 		electron.remote.dialog.showOpenDialog( window, {
-			filters: [
-				{ name: 'MrClippy Snapshots',
-					extensions: [ 'clip' ] },
-				{ name: 'All Files',
-					extensions: [ '*' ] }
+			filters: [ {
+				name: 'MrClippy Snapshots',
+				extensions: [ 'clip' ]
+			},
+			{
+				name: 'All Files',
+				extensions: [ '*' ]
+			}
 			],
 			properties: [ 'openFile' ]
 		}, fileNames => {

--- a/src/App.js
+++ b/src/App.js
@@ -16,8 +16,9 @@ class App {
 	constructor() {
 		this.controller = new MainWindowController( this );
 		this.storage = new Storage();
+		this.config = require( '../config.json' );
 
-		this.snapshots = new SnapshotList( this.storage.snapshots );
+		this.snapshots = new SnapshotList( this );
 
 		this.nav = new Navigation( this.controller, this.snapshots );
 		this.types = new Types( this.controller, this.snapshots );

--- a/src/Component/Navigation.js
+++ b/src/Component/Navigation.js
@@ -7,11 +7,27 @@ class Navigation extends Component {
 		super( controller, 'navigation' );
 		this.snapshots = snapshots;
 
+		this._listItems = new Map();
+
 		snapshots.on( 'added', this.addItem.bind( this ) );
+		snapshots.on( 'removed', this.removeItem.bind( this ) );
 	}
 
 	addItem( item ) {
-		this._elem.prepend( this.getNavigationFor( item ) );
+		let listItem = this.getNavigationFor( item );
+
+		this._elem.prepend( listItem );
+
+		this._listItems.set( item, listItem );
+	}
+
+	removeItem( item ) {
+		let listItem = this._listItems.get( item );
+
+		if ( listItem ) {
+			listItem.remove();
+			this._listItems.delete( item );
+		}
 	}
 
 	getNavigationFor( item ) {

--- a/src/Component/Types.js
+++ b/src/Component/Types.js
@@ -17,8 +17,10 @@ class Types extends Component {
 	snapshotSelected( item ) {
 		this._clear();
 
-		for ( let type of item.getTypes() ) {
-			this._elem.appendChild( this.getOptionFor( item, type ) );
+		if ( item ) {
+			for ( let type of item.getTypes() ) {
+				this._elem.appendChild( this.getOptionFor( item, type ) );
+			}
 		}
 	}
 

--- a/src/SnapshotsList.js
+++ b/src/SnapshotsList.js
@@ -42,15 +42,14 @@ class SnapshotsList extends EventEmitter {
 	async add( item ) {
 		if ( this._app.config.maxSnapshots > 0 && this._store.size >= this._app.config.maxSnapshots ) {
 			// In case we exceeded the limit, pick last one and remove it before adding a new snapshot.
-			this.remove( this.getLast() );
+			await this.remove( this.getLast() );
 		}
 
 		this._store.add( item );
 
 		if ( this._isStorageEnabled() ) {
 			if ( typeof item._storageKey === 'undefined' ) {
-				let keys = await this._storage.keys();
-				item._storageKey = String( keys.length );
+				item._storageKey = await this._app.storage.requestNewSnasphotKey();
 			}
 
 			await this._storage.setItem( item._storageKey, SnapshotStorer._getSnapshotObject( item ) );

--- a/src/SnapshotsList.js
+++ b/src/SnapshotsList.js
@@ -40,6 +40,11 @@ class SnapshotsList extends EventEmitter {
 	}
 
 	async add( item ) {
+		if ( this._app.config.maxSnapshots > 0 && this._store.size >= this._app.config.maxSnapshots ) {
+			// In case we exceeded the limit, pick last one and remove it before adding a new snapshot.
+			this.remove( this.getLast() );
+		}
+
 		this._store.add( item );
 
 		if ( this._isStorageEnabled() ) {
@@ -112,6 +117,13 @@ class SnapshotsList extends EventEmitter {
 			loadedSnapshot._storageKey = curKey;
 			this.add( loadedSnapshot );
 		}
+	}
+
+	/**
+	 * @returns {ClipboardSnapshot/undefined} Returns the last snapshot.
+	 */
+	getLast() {
+		return this._store.values().next().value;
 	}
 
 	/**

--- a/src/SnapshotsList.js
+++ b/src/SnapshotsList.js
@@ -66,6 +66,13 @@ class SnapshotsList extends EventEmitter {
 		this.emit( 'changed' );
 	}
 
+	/**
+	 * Clears snapshot list.
+	 */
+	async clear() {
+		this._store.forEach( snapshot => this.remove( snapshot ) );
+	}
+
 	select( item ) {
 		if ( item === this._selected ) {
 			return;

--- a/src/SnapshotsList.js
+++ b/src/SnapshotsList.js
@@ -57,7 +57,10 @@ class SnapshotsList extends EventEmitter {
 
 	async remove( item ) {
 		this._store.delete( item );
-		await this._storage.removeItem( item._storageKey );
+
+		if ( this._isStorageEnabled() ) {
+			await this._storage.removeItem( item._storageKey );
+		}
 
 		this.emit( 'removed', item );
 		this.emit( 'changed' );
@@ -86,6 +89,10 @@ class SnapshotsList extends EventEmitter {
 	 * Loads snapshot list from it's associated local storage.
 	 */
 	async loadFromStorage() {
+		if ( !this._isStorageEnabled() ) {
+			return;
+		}
+
 		let storage = this._storage,
 			keys = await storage.keys();
 

--- a/src/SnapshotsList.js
+++ b/src/SnapshotsList.js
@@ -56,6 +56,10 @@ class SnapshotsList extends EventEmitter {
 	}
 
 	async remove( item ) {
+		if ( item === this._selected ) {
+			this.select( null );
+		}
+
 		this._store.delete( item );
 
 		if ( this._isStorageEnabled() ) {

--- a/src/SnapshotsList.js
+++ b/src/SnapshotsList.js
@@ -1,26 +1,55 @@
 'use strict';
 
-const EventEmitter = require( 'events' );
+const ClipboardSnapshot = require( './ClipboardSnapshot' ),
+	SnapshotStorer = require( './SnapshotStorer' ),
+	EventEmitter = require( 'events' );
 
 class SnapshotsList extends EventEmitter {
-	constructor() {
+	constructor( storage ) {
 		super();
-		this._store = new Set();
+
+		/**
+		 * @private
+		 * @property {ClipboardSnapshot/null} _selected Currently selected snapshot.
+		 */
 		this._selected = null;
+
+		/**
+		 * In-memory store of clipboard snapshots.
+		 *
+		 * @property {Set<ClipboardSnapshot>}
+		 */
+		this._store = new Set();
+
+		/**
+		 * Persistent storage keeping the clipboard snapshots.
+		 *
+		 * @private
+		 * @property {Object} _storage LocalForage db instance.
+		 */
+		this._storage = storage;
 	}
 
-	add( item ) {
+	async add( item ) {
 		this._store.add( item );
+
+		if ( typeof item._storageKey === 'undefined' ) {
+			let keys = await this._storage.keys();
+			item._storageKey = String( keys.length );
+		}
+
+		await this._storage.setItem( item._storageKey, SnapshotStorer._getSnapshotObject( item ) );
 
 		this.emit( 'added', item );
 		this.emit( 'changed' );
 	}
 
-	remove( item ) {
-		if ( this._store.delete( item ) ) {
-			this.emit( 'removed', item );
-			this.emit( 'changed' );
-		}
+	async remove( item ) {
+		this._store.delete( item );
+		await this._storage.removeItem( item._storageKey );
+
+		this.emit( 'removed', item );
+		this.emit( 'changed' );
 	}
 
 	select( item ) {
@@ -40,6 +69,20 @@ class SnapshotsList extends EventEmitter {
 	 */
 	getSelected() {
 		return this._selected || null;
+	}
+
+	/**
+	 * Loads snapshot list from it's associated local storage.
+	 */
+	async loadFromStorage() {
+		let storage = this._storage,
+			keys = await storage.keys();
+
+		for ( let curKey of keys ) {
+			let loadedSnapshot = ClipboardSnapshot.createFromData( await storage.getItem( curKey ) );
+			loadedSnapshot._storageKey = curKey;
+			this.add( loadedSnapshot );
+		}
 	}
 }
 

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -23,6 +23,22 @@ class Storage {
 			console.log( `${key} "${( await this.snapshots.getItem( key ) ).meta.label.replace( /\x00/g, '' )}"` );
 		}
 	}
+
+	/**
+	 * Note that the returned key will not be reserved.
+	 *
+	 * @returns {Promise.<string>}
+	 */
+	async requestNewSnasphotKey() {
+		let keys = await this.snapshots.keys(),
+			ret = 0; // Default value for empty array.
+
+		if ( keys.length ) {
+			ret = String( parseInt( keys[ keys.length - 1 ] ) + 1 );
+		}
+
+		return String( ret );
+	}
 }
 
 module.exports = Storage;

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -20,7 +20,7 @@ class Storage {
 		let keys = await this.snapshots.keys();
 		for ( let key of keys ) {
 			// Replaces \0 chars due to #27.
-			console.log( `${key} "${( await this.storage.snapshots.getItem( key ) ).meta.label.replace( /\x00/g, '' )}"` );
+			console.log( `${key} "${( await this.snapshots.getItem( key ) ).meta.label.replace( /\x00/g, '' )}"` );
 		}
 	}
 }

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -1,0 +1,28 @@
+const localForage = require( 'localforage' );
+
+localForage.setDriver( [ localForage.INDEXEDDB, localForage.WEBSQL ] );
+
+class Storage {
+	constructor() {
+		this.snapshots = localForage.createInstance( {
+			name: 'mrclippy_snapshots'
+		} );
+	}
+
+	async clear() {
+		return await this.snapshots.clear();
+	}
+
+	/**
+	 * A temporary debug method to log items in clipboard snapshot storage.
+	 */
+	async dumpStorage() {
+		let keys = await this.snapshots.keys();
+		for ( let key of keys ) {
+			// Replaces \0 chars due to #27.
+			console.log( `${key} "${( await this.storage.snapshots.getItem( key ) ).meta.label.replace( /\x00/g, '' )}"` );
+		}
+	}
+}
+
+module.exports = Storage;

--- a/src/Viewer/Html/Render.js
+++ b/src/Viewer/Html/Render.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const Viewer = require( '../Viewer' );
+const Viewer = require( '../Viewer' ),
+	utf8decoder = new TextDecoder( 'utf8' );
 
 class Text extends Viewer {
 	constructor() {
@@ -26,7 +27,7 @@ class Text extends Viewer {
 	 * @param {HTMLElement} element A wrapper element where the content preview have to be rendered.
 	 */
 	display( item, type, element ) {
-		let html = item.getValue( type );
+		let html = utf8decoder.decode( item.getValue( type ) );
 
 		// For Windows, the display value needs to be further sanitized.
 		if ( process.platform == 'win32' ) {

--- a/src/Viewer/Text.js
+++ b/src/Viewer/Text.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const Viewer = require( './Viewer' ),
-	iconv = require( 'iconv-lite' );
+	utf8decoder = new TextDecoder( 'utf8' ),
+	utf16decoder = new TextDecoder( 'utf-16le' );
 
 class Text extends Viewer {
 	constructor() {
@@ -30,8 +31,8 @@ class Text extends Viewer {
 	display( item, type, element ) {
 		let bytes = item.getValue( type ),
 			isWinClipboard = item.env.name == 'win32',
-			string = ( isWinClipboard && type === 'CF_UNICODETEXT' ) ?
-				iconv.decode( bytes, 'utf-16le' ) : String( bytes );
+			decoder = ( isWinClipboard && type === 'CF_UNICODETEXT' ) ? utf16decoder : utf8decoder,
+			string = decoder.decode( bytes );
 
 		if ( isWinClipboard && string[ string.length - 1 ] === '\0' ) {
 			// Windows always adds NULL byte char at the end.

--- a/tests/SnapshotsList.test.js
+++ b/tests/SnapshotsList.test.js
@@ -63,7 +63,7 @@ describe( 'SnapshotsList', () => {
 
 		after( () => {
 			mockSnapshot._storageKey = initialStorageKey;
-		});
+		} );
 
 		it( 'Removes the item from storage', async() => {
 			await listMock.remove( mockSnapshot );

--- a/tests/SnapshotsList.test.js
+++ b/tests/SnapshotsList.test.js
@@ -1,18 +1,11 @@
 const ClipboardSnapshotMock = require( './mock/ClipboardSnapshotMock' ),
+	AppMock = require( './mock/AppMock' ),
 	SnapshotsList = require( '../src/SnapshotsList' );
 
 describe( 'SnapshotsList', () => {
-	let storageMock = {
-			keys() {
-				return 3;
-			},
-			setItem() {},
-			getItem() {
-				return 55;
-			},
-			removeItem() {}
-		},
-		listMock = new SnapshotsList( storageMock ),
+	let appMock = new AppMock(),
+		listMock = new SnapshotsList( appMock ),
+		storageMock = appMock.storage.snapshots,
 		sandbox = sinon.createSandbox();
 
 	const mockSnapshot = new ClipboardSnapshotMock( {
@@ -77,5 +70,22 @@ describe( 'SnapshotsList', () => {
 			expect( listMock.emit.firstCall ).to.be.calledWithExactly( 'removed', mockSnapshot );
 			expect( listMock.emit ).to.be.calledWithExactly( 'changed' );
 		} );
+	} );
+
+	describe( 'config.persistentStorage = false', () => {
+		let initialConfigValue = appMock.config.persistentStorage;
+
+		before( () => appMock.config.persistentStorage = false );
+		after( () => appMock.config.persistentStorage = initialConfigValue );
+
+		it( 'Does not create storage entry with add', async() => {
+			await listMock.add( mockSnapshot );
+
+			expect( storageMock.setItem ).not.to.be.called;
+		} );
+
+		it( 'Does not modify storage on remove', () => {} );
+
+		it( 'Does not load entries in loadFromStorage', () => {} );
 	} );
 } );

--- a/tests/SnapshotsList.test.js
+++ b/tests/SnapshotsList.test.js
@@ -1,0 +1,81 @@
+const ClipboardSnapshotMock = require( './mock/ClipboardSnapshotMock' ),
+	SnapshotsList = require( '../src/SnapshotsList' );
+
+describe( 'SnapshotsList', () => {
+	let storageMock = {
+			keys() {
+				return 3;
+			},
+			setItem() {},
+			getItem() {
+				return 55;
+			},
+			removeItem() {}
+		},
+		listMock = new SnapshotsList( storageMock ),
+		sandbox = sinon.createSandbox();
+
+	const mockSnapshot = new ClipboardSnapshotMock( {
+		'HTML Format': Buffer.from( [ 31, 32, 33 ] ),
+		CF_UNICODETEXT: Buffer.from( [ 31, 0, 32, 0, 33, 0 ] ),
+		Binary: Buffer.from( [ 64, 64, 64 ] )
+	} );
+
+	before( () => {
+		sandbox.stub( storageMock, 'keys' );
+		sandbox.stub( storageMock, 'setItem' );
+		sandbox.stub( storageMock, 'getItem' );
+		sandbox.stub( storageMock, 'removeItem' );
+
+		sandbox.stub( listMock, 'emit' );
+	} );
+
+	beforeEach( () => {
+		sandbox.reset();
+		storageMock.keys.resolves( [] );
+	} );
+
+	describe( 'add()', () => {
+		it( 'Adds the item to persistent storage', async() => {
+			const SnapshotStorer = require( '../src/SnapshotStorer' );
+
+			await listMock.add( mockSnapshot );
+
+			expect( storageMock.setItem ).to.be.calledWith( '0', SnapshotStorer._getSnapshotObject( mockSnapshot ) );
+		} );
+
+		it( 'Fires added and changed events', async() => {
+			await listMock.add( mockSnapshot );
+
+			// Make sure first added event is fired.
+			expect( listMock.emit.firstCall ).to.be.calledWithExactly( 'added', mockSnapshot );
+			expect( listMock.emit ).to.be.calledWithExactly( 'changed' );
+		} );
+	} );
+
+	describe( 'remove()', () => {
+		let initialStorageKey = mockSnapshot._storageKey;
+
+		beforeEach( () => {
+			listMock._store.add( mockSnapshot );
+			mockSnapshot._storageKey = '10';
+		} );
+
+		after( () => {
+			mockSnapshot._storageKey = initialStorageKey;
+		});
+
+		it( 'Removes the item from storage', async() => {
+			await listMock.remove( mockSnapshot );
+			expect( storageMock.removeItem ).to.be.calledWith( '10' );
+		} );
+
+		it( 'Fires added and changed events', async() => {
+			await listMock.remove( mockSnapshot );
+
+			// Make sure first added event is fired.
+			expect( listMock.emit.firstCall ).to.be.calledWithExactly( 'removed', mockSnapshot );
+			expect( listMock.emit ).to.be.calledWithExactly( 'changed' );
+		} );
+	} );
+} );

--- a/tests/SnapshotsList.test.js
+++ b/tests/SnapshotsList.test.js
@@ -129,4 +129,24 @@ describe( 'SnapshotsList', () => {
 			expect( storageMock.getItem ).not.to.be.called;
 		} );
 	} );
+
+	describe( 'config.maxSnapshots = 3', () => {
+		let initialConfigValue = appMock.config.maxSnapshots;
+
+		before( () => appMock.config.maxSnapshots = 3 );
+		after( () => appMock.config.maxSnapshots = initialConfigValue );
+
+		it( 'Does not create storage entry with add', async() => {
+			let thirdItem = new ClipboardSnapshotMock( {} );
+
+			await listMock.add( mockSnapshot );
+			await listMock.add( new ClipboardSnapshotMock( {} ) );
+			await listMock.add( thirdItem );
+			await listMock.add( new ClipboardSnapshotMock( {} ) );
+			await listMock.add( new ClipboardSnapshotMock( {} ) );
+
+			expect( listMock._store ).to.have.property( 'size', 3 );
+			expect( listMock.getLast() ).to.be.equal( thirdItem );
+		} );
+	} );
 } );

--- a/tests/SnapshotsList.test.js
+++ b/tests/SnapshotsList.test.js
@@ -70,6 +70,15 @@ describe( 'SnapshotsList', () => {
 			expect( listMock.emit.firstCall ).to.be.calledWithExactly( 'removed', mockSnapshot );
 			expect( listMock.emit ).to.be.calledWithExactly( 'changed' );
 		} );
+
+		it( 'Unselects removed element if needed', async() => {
+			listMock.select( mockSnapshot );
+
+			await listMock.remove( mockSnapshot );
+
+			expect( listMock.getSelected() ).to.be.null;
+			expect( listMock.emit ).to.be.calledWithExactly( 'selected', null, mockSnapshot );
+		} );
 	} );
 
 	describe( 'clear()', () => {

--- a/tests/SnapshotsList.test.js
+++ b/tests/SnapshotsList.test.js
@@ -72,6 +72,28 @@ describe( 'SnapshotsList', () => {
 		} );
 	} );
 
+	describe( 'clear()', () => {
+		let removeStub;
+
+		before( () => removeStub = sinon.spy( listMock, 'remove' ) );
+
+		after( () => removeStub.restore() );
+
+		it( 'works', async() => {
+			let snapshot2 = new ClipboardSnapshotMock( {} );
+
+			await listMock.add( mockSnapshot );
+			await listMock.add( snapshot2 );
+
+			await listMock.clear();
+
+			expect( listMock.remove ).to.be.calledWithExactly( mockSnapshot );
+			expect( listMock.remove ).to.be.calledWithExactly( snapshot2 );
+
+			expect( listMock._store ).is.empty;
+		} );
+	} );
+
 	describe( 'config.persistentStorage = false', () => {
 		let initialConfigValue = appMock.config.persistentStorage;
 

--- a/tests/SnapshotsList.test.js
+++ b/tests/SnapshotsList.test.js
@@ -84,8 +84,18 @@ describe( 'SnapshotsList', () => {
 			expect( storageMock.setItem ).not.to.be.called;
 		} );
 
-		it( 'Does not modify storage on remove', () => {} );
+		it( 'Does not modify storage on remove', async() => {
+			await listMock.add( mockSnapshot );
+			await listMock.remove( mockSnapshot );
 
-		it( 'Does not load entries in loadFromStorage', () => {} );
+			expect( storageMock.removeItem ).not.to.be.called;
+		} );
+
+		it( 'Does not load entries in loadFromStorage', async() => {
+			await listMock.loadFromStorage();
+
+			expect( storageMock.keys ).not.to.be.called;
+			expect( storageMock.getItem ).not.to.be.called;
+		} );
 	} );
 } );

--- a/tests/_fixtures/config.json
+++ b/tests/_fixtures/config.json
@@ -1,0 +1,4 @@
+{
+	"persistentStorage": true,
+	"maxSnapshots": 50
+}

--- a/tests/mock/AppMock.js
+++ b/tests/mock/AppMock.js
@@ -1,0 +1,10 @@
+const Storage = require( '../../src/Storage' );
+
+class AppMock {
+	constructor() {
+		this.config = require( '../_fixtures/config.json' );
+		this.storage = new Storage();
+	}
+}
+
+module.exports = AppMock;

--- a/tests/mock/AppMock.js
+++ b/tests/mock/AppMock.js
@@ -1,9 +1,17 @@
-const Storage = require( '../../src/Storage' );
-
 class AppMock {
 	constructor() {
 		this.config = require( '../_fixtures/config.json' );
-		this.storage = new Storage();
+
+		// Can't use real localforage instance, or it will throw: "UnhandledPromiseRejectionWarning: Unhandled promise
+		// rejection (rejection id: 10): Error: No available storage method found." error.
+		this.storage = {
+			snapshots: {
+				keys: () => null,
+				setItem: () => null,
+				getItem: () => null,
+				removeItem: () => null
+			}
+		};
 	}
 }
 


### PR DESCRIPTION
This PR enhancements for:

* Ability to save clipboard snapshots in a persistent storage, so that it's kept between the sessions #30. It's done using [localForage](https://github.com/localForage/localForage), with a preference to `localForage.INDEXEDDB`.
* Config option for limiting snapshot count #41.
* Config option for disabling persistent storage #40.

Closes #40, closes #41, closes #30.