### PR TITLE
Prevent dumplication of clipboard for the latest item

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
 	"persistentStorage": true,
-	"maxSnapshots": 50
+	"maxSnapshots": 50,
+	"allowSubsequentDuplicates": false
 }

--- a/src/App.js
+++ b/src/App.js
@@ -109,7 +109,7 @@ class App {
 		let newSnapshot = ClipboardSnapshot.createFromClipboard(),
 			last = this.snapshots.getFirst();
 
-		if ( last && last.equals( newSnapshot ) && confirm( 'Dude, you already have a snapshot like that, would you like to reuse it?' ) ) {
+		if ( !this.config.allowSubsequentDuplicates && last && last.equals( newSnapshot ) ) {
 			this.snapshots.select( last );
 			return last;
 		}

--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,7 @@ class App {
 		} );
 
 		// By default capture current clipboard snapshot, and select it.
-		this.snapshots.select( this.captureSnapshot() );
+		await this.captureSnapshot();
 	}
 
 	/**
@@ -105,12 +105,19 @@ class App {
 	 *
 	 * @returns {ClipboardSnapshot}
 	 */
-	captureSnapshot() {
-		let initialSnapshot = ClipboardSnapshot.createFromClipboard();
+	async captureSnapshot() {
+		let newSnapshot = ClipboardSnapshot.createFromClipboard(),
+			last = this.snapshots.getFirst();
 
-		this.snapshots.add( initialSnapshot );
+		if ( last && last.equals( newSnapshot ) && confirm( 'Dude, you already have a snapshot like that, would you like to reuse it?' ) ) {
+			this.snapshots.select( last );
+			return last;
+		}
 
-		return initialSnapshot;
+		await this.snapshots.add( newSnapshot );
+		this.snapshots.select( newSnapshot );
+
+		return newSnapshot;
 	}
 }
 

--- a/src/Component/Navigation.js
+++ b/src/Component/Navigation.js
@@ -11,6 +11,7 @@ class Navigation extends Component {
 
 		snapshots.on( 'added', this.addItem.bind( this ) );
 		snapshots.on( 'removed', this.removeItem.bind( this ) );
+		snapshots.on( 'selected', this.itemSelected.bind( this ) );
 	}
 
 	addItem( item ) {
@@ -30,19 +31,25 @@ class Navigation extends Component {
 		}
 	}
 
+	itemSelected( item, prevSelected ) {
+		let prevItem = prevSelected && this._listItems.get( prevSelected ),
+			curItem = item && this._listItems.get( item );
+
+		if ( prevItem ) {
+			prevItem.classList.remove( 'active' );
+		}
+
+		if ( curItem ) {
+			curItem.classList.add( 'active' );
+		}
+	}
+
 	getNavigationFor( item ) {
 		let ret = document.createElement( 'button' );
 		ret.classList = 'item list-group-item list-group-item-action btn-sm';
 		ret.innerHTML = item.getLabel();
 		ret.addEventListener( 'click', () => {
 			this.snapshots.select( item );
-
-			let curActiveType = this._elem.querySelector( '.active' );
-			if ( curActiveType ) {
-				curActiveType.classList.remove( 'active' );
-			}
-
-			ret.classList.add( 'active' );
 		} );
 		return ret;
 	}

--- a/src/SnapshotsList.js
+++ b/src/SnapshotsList.js
@@ -114,7 +114,7 @@ class SnapshotsList extends EventEmitter {
 		for ( let curKey of keys ) {
 			let loadedSnapshot = ClipboardSnapshot.createFromData( await storage.getItem( curKey ) );
 			loadedSnapshot._storageKey = curKey;
-			this.add( loadedSnapshot );
+			await this.add( loadedSnapshot );
 		}
 	}
 

--- a/src/SnapshotsList.js
+++ b/src/SnapshotsList.js
@@ -47,10 +47,9 @@ class SnapshotsList extends EventEmitter {
 
 		this._store.add( item );
 
-		if ( this._isStorageEnabled() ) {
-			if ( typeof item._storageKey === 'undefined' ) {
-				item._storageKey = await this._app.storage.requestNewSnapshotKey();
-			}
+		if ( this._isStorageEnabled() && typeof item._storageKey === 'undefined' ) {
+			// Item is not yet added to the persistent storage.
+			item._storageKey = await this._app.storage.requestNewSnapshotKey();
 
 			await this._storage.setItem( item._storageKey, SnapshotStorer._getSnapshotObject( item ) );
 		}

--- a/src/SnapshotsList.js
+++ b/src/SnapshotsList.js
@@ -125,6 +125,16 @@ class SnapshotsList extends EventEmitter {
 		return this._store.values().next().value;
 	}
 
+	getFirst() {
+		let lastVal;
+
+		for ( let val of this._store.values() ) {
+			lastVal = val;
+		}
+
+		return lastVal;
+	}
+
 	/**
 	 * Tells whether persistent storage is enabled.
 	 *

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -34,7 +34,7 @@ class Storage {
 			ret = 0; // Default value for empty array.
 
 		if ( keys.length ) {
-			ret = String( parseInt( keys[ keys.length - 1 ] ) + 1 );
+			ret = Math.max.apply( window, keys.map( key => parseInt( key ) ) ) + 1;
 		}
 
 		return String( ret );


### PR DESCRIPTION
This PR prevents duplication of snapshots added on top of the clipboard.

MrClippy makes a snapshot when launching the app, which till now was resulting with multiple equal snapshots if you had the same clipboard content.

Still one can disable this option with `config.allowSubsequentDuplicates` option.

Closes #39.