### PR TITLE
Added a function to edit snapshot labels

### DIFF
--- a/index.css
+++ b/index.css
@@ -15,6 +15,24 @@ html .list-group-item {
 	padding: 0.18em 0.3em;
 }
 
+#navigation .list-group-item {
+	padding: 0.1em 0;
+}
+
+#navigation .list-group-item {
+	background: red;
+}
+
+#navigation .list-group-item:first-child {
+	border-top-left-radius: 0.5em;
+	border-top-right-radius: 0.5em;
+}
+
+#navigation .list-group-item:last-child {
+	border-bottom-left-radius: 0.5em;
+	border-bottom-right-radius: 0.5em;
+}
+
 html .btn {
 	padding: 0.1em 1.0em;
 }
@@ -25,14 +43,35 @@ html .btn {
 	padding-right: 0.5rem;
 }
 
-#navigation .edit-btn,
-#navigation .remove-btn {
+#navigation {
+	display: flex;
+	flex-direction: column;
+}
+
+#navigation .list-group-item {
+	display: flex;
+	flex-direction: row;
+	align-content: stretch;
+	align-items: stretch;
+}
+
+#navigation .list-group-item:not(.active) button.edit-btn,
+#navigation .list-group-item:not(.active) button.remove-btn {
 	display: none;
+}
+
+#navigation .list-group-item .label-btn {
+	flex: 1;
+}
+
+#navigation .list-group-item > * {
+	display: flex;
 }
 
 #navigation .active .edit-btn,
 #navigation .active .remove-btn {
-	display: inline;
+	border-left: 1px solid rgba(0, 0, 0, 0.425);
+	padding: 0.2em;
 }
 
 .preview-iframe {
@@ -40,3 +79,17 @@ html .btn {
 	width: 100%;
 	border: 0px;
 }
+
+/*
+#navigation .list-group-item {
+	display: flex;
+}
+
+#navigation .list-group-item button {
+	display: flex;
+	padding: 0px;
+}
+
+.label-btn {
+	align-self: stretch;
+} */

--- a/index.css
+++ b/index.css
@@ -47,10 +47,14 @@ html .btn {
     border-color: #007bff;
 }
 
-#navigation .list-group-item .label-btn {
+#navigation .list-group-item .label-btn,
+#navigation .list-group-item input {
 	flex: 1;
 	flex-shrink: 1;
 	min-width: 0; /* Otherwise label would overflow outside of it's wrapper. */
+}
+
+#navigation .list-group-item .label-btn {
 	overflow: hidden;
 	text-overflow: ellipsis;
 }

--- a/index.css
+++ b/index.css
@@ -25,6 +25,16 @@ html .btn {
 	padding-right: 0.5rem;
 }
 
+#navigation .edit-btn,
+#navigation .remove-btn {
+	display: none;
+}
+
+#navigation .active .edit-btn,
+#navigation .active .remove-btn {
+	display: inline;
+}
+
 .preview-iframe {
 	display: block;
 	width: 100%;

--- a/index.css
+++ b/index.css
@@ -79,17 +79,3 @@ html .btn {
 	width: 100%;
 	border: 0px;
 }
-
-/*
-#navigation .list-group-item {
-	display: flex;
-}
-
-#navigation .list-group-item button {
-	display: flex;
-	padding: 0px;
-}
-
-.label-btn {
-	align-self: stretch;
-} */

--- a/index.css
+++ b/index.css
@@ -15,24 +15,6 @@ html .list-group-item {
 	padding: 0.18em 0.3em;
 }
 
-#navigation .list-group-item {
-	padding: 0.1em 0;
-}
-
-#navigation .list-group-item {
-	background: red;
-}
-
-#navigation .list-group-item:first-child {
-	border-top-left-radius: 0.5em;
-	border-top-right-radius: 0.5em;
-}
-
-#navigation .list-group-item:last-child {
-	border-bottom-left-radius: 0.5em;
-	border-bottom-right-radius: 0.5em;
-}
-
 html .btn {
 	padding: 0.1em 1.0em;
 }
@@ -62,6 +44,10 @@ html .btn {
 
 #navigation .list-group-item .label-btn {
 	flex: 1;
+	flex-shrink: 1;
+	min-width: 0; /* Otherwise label would overflow outside of it's wrapper. */
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 #navigation .list-group-item > * {
@@ -78,4 +64,8 @@ html .btn {
 	display: block;
 	width: 100%;
 	border: 0px;
+}
+
+html .btn-light:focus, html .btn-light.focus {
+	box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
 }

--- a/index.css
+++ b/index.css
@@ -37,9 +37,14 @@ html .btn {
 	align-items: stretch;
 }
 
-#navigation .list-group-item:not(.active) button.edit-btn,
-#navigation .list-group-item:not(.active) button.remove-btn {
-	display: none;
+#navigation .active {
+	background-color: inherit;
+}
+
+#navigation .active .btn {
+    color: #fff;
+    background-color: #007bff;
+    border-color: #007bff;
 }
 
 #navigation .list-group-item .label-btn {
@@ -68,4 +73,8 @@ html .btn {
 
 html .btn-light:focus, html .btn-light.focus {
 	box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+}
+
+.hidden, #navigation .list-group-item .hidden {
+	display: none;
 }

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
 					<button class="btn btn-success btn-xl" onclick="app.captureSnapshot()">Capture a snapshot</button>
 					<button class="btn btn-xl" onclick="app.openSnapshot()">Open</button>
 					<button class="btn btn-xl" onclick="app.saveSnapshot()">Save</button>
-					<button class="btn brn-error btn-xl" onclick="app.snapshots.remove( app.snapshots.getSelected() )">Remove selected</button>
 					<button class="btn btn-xl" onclick="app.writeSnapshot( app.snapshots.getSelected() );" data-toggle="tooltip" title="Write currently selected snapshot to your OS clipboard">Write</button>
 				</div>
 			</div>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 		</header>
 		<div class="container-fluid">
 			<div class="row">
-				<div id="navigation" class="col list-group"></div>
+				<ol id="navigation" class="col list-group"></ol>
 				<div id="types" class="col list-group"></div>
 				<div id="preview" class="col">
 					<div id="previewTypes" class="row"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mrclippy",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mrclippy",
   "productName": "MrClippy",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A simple clipboard editor.",
   "license": "MIT",
   "repository": "mlewand/mrclippy",

--- a/src/ClipboardSnapshot.js
+++ b/src/ClipboardSnapshot.js
@@ -2,16 +2,19 @@
 	'use strict';
 
 	const LABEL_MAX_LENGTH = 50,
+		EventEmitter = require( 'events' ),
 		clipboard = require( './clipboard' ),
 		OsEnvironment = require( './OsEnvironment' ),
 		crc32 = require( 'crc-32' );
 
-	class ClipboardSnapshot {
+	class ClipboardSnapshot extends EventEmitter {
 		/**
 		 * @param {OsEnvironment} [env=null] Environment for which the snapshot was taken. If skipped it will be
 		 * detected automatically.
 		 */
 		constructor( env ) {
+			super();
+
 			this._content = new Map();
 			/**
 			 * Environment info for the platform that was used to create this snapshot.
@@ -39,6 +42,16 @@
 
 		getLabel() {
 			return this.label;
+		}
+
+		setLabel( newVal ) {
+			let proposedVal = String( newVal );
+			proposedVal = proposedVal.substr( 0, LABEL_MAX_LENGTH ) + ( proposedVal.length > LABEL_MAX_LENGTH ? '…' : '' );
+
+			if ( proposedVal !== this.label ) {
+				this.label = proposedVal;
+				this.emit( 'changed' );
+			}
 		}
 
 		/**
@@ -91,7 +104,7 @@
 			let textValue = clipboard.readText().trim();
 
 			if ( textValue.length ) {
-				ret.label = textValue.substr( 0, LABEL_MAX_LENGTH ) + ( textValue.length > LABEL_MAX_LENGTH ? '…' : '' );
+				ret.setLabel( textValue );
 			}
 
 			return ret;

--- a/src/Component/Navigation.js
+++ b/src/Component/Navigation.js
@@ -45,13 +45,39 @@ class Navigation extends Component {
 	}
 
 	getNavigationFor( item ) {
-		let ret = document.createElement( 'button' );
-		ret.classList = 'item list-group-item list-group-item-action btn-sm';
-		ret.innerHTML = item.getLabel();
-		ret.addEventListener( 'click', () => {
+		let ret = document.createElement( 'div' );
+		ret.classList = 'item list-group-item list-group-item-action btn-group no-gutters';
+
+		let snapshotButton = document.createElement( 'a' );
+		snapshotButton.classList = 'btn';
+		snapshotButton.innerHTML = item.getLabel();
+		snapshotButton.addEventListener( 'click', () => {
 			this.snapshots.select( item );
 		} );
+
+		let labelEdit = document.createElement( 'span' );
+		labelEdit.classList = 'edit-btn';
+		labelEdit.innerHTML = '✍';
+		labelEdit.addEventListener( 'click', () => {
+			this.editItem( item );
+		} );
+
+		let labelRemove = document.createElement( 'span' );
+		labelRemove.classList = 'remove-btn';
+		labelRemove.innerHTML = '🗑';
+		labelRemove.addEventListener( 'click', () => {
+			this.snapshots.remove( item );
+		} );
+
+		ret.appendChild( snapshotButton );
+		ret.appendChild( labelEdit );
+		ret.appendChild( labelRemove );
+
 		return ret;
+	}
+
+	editItem( item ) {
+		console.log( `You're about to edit item ${item.getLabel()}` );
 	}
 }
 

--- a/src/Component/Navigation.js
+++ b/src/Component/Navigation.js
@@ -45,25 +45,25 @@ class Navigation extends Component {
 	}
 
 	getNavigationFor( item ) {
-		let ret = document.createElement( 'div' );
-		ret.classList = 'item list-group-item list-group-item-action btn-group no-gutters';
+		let ret = document.createElement( 'li' );
+		ret.classList = 'item list-group-item list-group-item-action no-gutters btn-group';
 
-		let snapshotButton = document.createElement( 'a' );
-		snapshotButton.classList = 'btn';
+		let snapshotButton = document.createElement( 'button' );
+		snapshotButton.classList = 'clip-button label-btn btn btn-primary';
 		snapshotButton.innerHTML = item.getLabel();
 		snapshotButton.addEventListener( 'click', () => {
 			this.snapshots.select( item );
 		} );
 
-		let labelEdit = document.createElement( 'span' );
-		labelEdit.classList = 'edit-btn';
+		let labelEdit = document.createElement( 'button' );
+		labelEdit.classList = 'clip-button edit-btn btn btn-primary';
 		labelEdit.innerHTML = '✍';
 		labelEdit.addEventListener( 'click', () => {
 			this.editItem( item );
 		} );
 
-		let labelRemove = document.createElement( 'span' );
-		labelRemove.classList = 'remove-btn';
+		let labelRemove = document.createElement( 'button' );
+		labelRemove.classList = 'clip-button remove-btn btn btn-primary';
 		labelRemove.innerHTML = '🗑';
 		labelRemove.addEventListener( 'click', () => {
 			this.snapshots.remove( item );

--- a/src/Component/Navigation.js
+++ b/src/Component/Navigation.js
@@ -41,6 +41,8 @@ class Navigation extends Component {
 
 		if ( curItem ) {
 			curItem.classList.add( 'active' );
+
+			this._appendNavigationSubActions( item );
 		}
 	}
 
@@ -49,35 +51,53 @@ class Navigation extends Component {
 		ret.classList = 'item list-group-item list-group-item-action no-gutters btn-group';
 
 		let snapshotButton = document.createElement( 'button' );
-		snapshotButton.classList = 'clip-button label-btn btn btn-primary';
+		snapshotButton.classList = 'clip-button label-btn btn btn-light';
 		snapshotButton.innerHTML = item.getLabel();
 		snapshotButton.addEventListener( 'click', () => {
 			this.snapshots.select( item );
 		} );
 
-		let labelEdit = document.createElement( 'button' );
-		labelEdit.classList = 'clip-button edit-btn btn btn-primary';
-		labelEdit.innerHTML = '✍';
-		labelEdit.addEventListener( 'click', () => {
-			this.editItem( item );
-		} );
-
-		let labelRemove = document.createElement( 'button' );
-		labelRemove.classList = 'clip-button remove-btn btn btn-primary';
-		labelRemove.innerHTML = '🗑';
-		labelRemove.addEventListener( 'click', () => {
-			this.snapshots.remove( item );
-		} );
-
 		ret.appendChild( snapshotButton );
-		ret.appendChild( labelEdit );
-		ret.appendChild( labelRemove );
 
 		return ret;
 	}
 
 	editItem( item ) {
 		console.log( `You're about to edit item ${item.getLabel()}` );
+	}
+
+	/**k
+	 * Appends buttons for sub-actions for a given snapshot item. It also make sure to remove these buttons for previously
+	 * selected snapshot item.
+	 *
+	 * @private
+	 * @param {ClipboardSnapshot} item Item that the buttons should be added for.
+	 */
+	_appendNavigationSubActions( item ) {
+		// First remove old buttons.
+		this._elem.querySelectorAll( '.edit-btn, .remove-btn' ).forEach( el => el.remove() );
+
+		// Now add new buttons.
+		// Technically it would be nice to just move buttons found above to the new wrapper and adjust the onclick listener
+		// so it dynamically picks clicked snapshot, but it's fine for now.
+		let targetWrapper = this._listItems.get( item ),
+			labelEdit = document.createElement( 'button' ),
+			labelRemove = document.createElement( 'button' );
+
+		labelEdit.classList = 'clipi-button edit-btn btn btn-light';
+		labelEdit.innerHTML = '✍';
+		labelEdit.addEventListener( 'click', () => {
+			this.editItem( item );
+		} );
+
+		labelRemove.classList = 'clip-button remove-btn btn btn-light';
+		labelRemove.innerHTML = '🗑';
+		labelRemove.addEventListener( 'click', () => {
+			this.snapshots.remove( item );
+		} );
+
+		targetWrapper.appendChild( labelEdit );
+		targetWrapper.appendChild( labelRemove );
 	}
 }
 

--- a/src/SnapshotsList.js
+++ b/src/SnapshotsList.js
@@ -56,6 +56,14 @@ class SnapshotsList extends EventEmitter {
 
 		this.emit( 'added', item );
 		this.emit( 'changed' );
+
+		// As item gets changed, the changes has to be reflected in storage.
+		// @todo: extract this logic to a dedicated snapshot provider type.
+		item.on( 'changed', () => {
+			if ( item._storageKey ) {
+				this._storage.setItem( item._storageKey, SnapshotStorer._getSnapshotObject( item ) );
+			}
+		} );
 	}
 
 	async remove( item ) {


### PR DESCRIPTION
This PR adds an ability to edit the snapshot label.

![Label edit button location](https://i.imgur.com/4BTtgPi.png)

Below is how it looks like during the edit:

![Label being edited](https://i.imgur.com/7Y9XrjL.png)

Also it puts remove snapshot button next to affected snapshot, instead of having a "remove currently selected snapshot" button in the top area.

On top of it, it includes styling improvements for snapshots navigation list.

Closes #19, closes #13.