### PR TITLE
Introduced Text and HTML clipboard editors

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,4 +1,4 @@
-#previewTypes .btn {
+#previewMenu .btn {
 	margin-right: 0.2em;
 }
 
@@ -6,7 +6,7 @@
 	font-size: 0.9em
 }
 
-#previewTypes {
+#previewMenu {
 	padding-bottom: 0.2em;
 	border-bottom: 1px solid rgba(0, 0, 0, 0.125);
 }

--- a/index.css
+++ b/index.css
@@ -88,3 +88,8 @@ textarea.text-editor {
 	flex: 1;
 	min-height: 500px;
 }
+
+#editor, #monaco-editor {
+	min-height: 300px;
+	width: 100%;
+}

--- a/index.css
+++ b/index.css
@@ -79,6 +79,12 @@ html .btn-light:focus, html .btn-light.focus {
 	box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
 }
 
-.hidden, #navigation .list-group-item .hidden {
+html .hidden, #navigation .list-group-item .hidden {
 	display: none;
+}
+
+textarea.text-editor {
+	display: flex;
+	flex: 1;
+	min-height: 500px;
 }

--- a/index.html
+++ b/index.html
@@ -26,7 +26,12 @@
 				<ol id="navigation" class="col list-group"></ol>
 				<div id="types" class="col list-group"></div>
 				<div id="preview" class="col">
-					<div id="previewTypes" class="row"></div>
+					<div id="previewMenu" class="row">
+						<div id="previewTypes" class="col"></div>
+						<div id="previewOptions" class="col col-2">
+							<button class="btn btn-xl">Edit</button>
+						</div>
+					</div>
 					<div id="render" class="row"></div>
 					<div id="content" class="row align-items-center"></div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -29,10 +29,11 @@
 					<div id="previewMenu" class="row">
 						<div id="previewTypes" class="col"></div>
 						<div id="previewOptions" class="col col-2">
-							<button class="btn btn-xl">Edit</button>
+							<button class="btn btn-xl edit-btn hidden">Edit</button>
 						</div>
 					</div>
 					<div id="render" class="row"></div>
+					<div id="editor" class="row"></div>
 					<div id="content" class="row align-items-center"></div>
 				</div>
 			</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2145,6 +2145,11 @@
         "caller-id": "0.1.0"
       }
     },
+    "monaco-editor": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.10.1.tgz",
+      "integrity": "sha1-jJbE8VtrUli/ksvek8rYp+MAfhQ="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "is-buffer": "^1.1.6",
     "jszip": "^3.1.5",
     "localforage": "^1.5.5",
+    "monaco-editor": "^0.10.1",
     "pad": "^1.1.0",
     "sanitize-filename": "^1.6.1",
     "win-clipboard": "^0.0.5"

--- a/src/ClipboardSnapshot.js
+++ b/src/ClipboardSnapshot.js
@@ -61,6 +61,8 @@
 
 			this._content.set( type, data );
 
+			this._hashesCached = null;
+
 			this.emit( 'changed' );
 		}
 

--- a/src/ClipboardSnapshot.js
+++ b/src/ClipboardSnapshot.js
@@ -45,6 +45,25 @@
 			return this._content.get( type );
 		}
 
+		/**
+		 * @param {string} type Clipboard type to be written e.g. `'HTML Format'` or `'CF_UNICODETEXT'`.
+		 * @param {Buffer/Uint8Array} data Data to be written.
+		 */
+		setValue( type, data ) {
+			if ( !isBuffer( data ) ) {
+				console.error( `ClipboardSnapshot.setValue() invalid argument, expected buffer while ${typeof data} was given.` );
+			}
+
+			if ( this._content.has( type ) && deepEql( this._content.get( type ), data ) ) {
+				// If entries are the same, no reason to process it.
+				return;
+			}
+
+			this._content.set( type, data );
+
+			this.emit( 'changed' );
+		}
+
 		getLabel() {
 			return this.label;
 		}

--- a/src/Component/Previews.js
+++ b/src/Component/Previews.js
@@ -21,19 +21,36 @@ class Previews extends Component {
 			if ( viewer.handles( type ) ) {
 				this._elem.appendChild( this.getTabFor( item, type, viewer, viewerName ) );
 			}
-			// this._elem.appendChild( this.getTabFor( item, type ) );
 		}
 	}
 
 	getTabFor( item, type, viewer, viewerName ) {
 		let ret = document.createElement( 'button' );
-		ret.classList = 'btn btn-primary';
+		ret.classList = 'btn';
 		ret.innerText = viewer.label;
+		ret.dataset.viewerName = viewerName;
 		ret.addEventListener( 'click', () => {
 			this.controller.previewItem( item, type, viewerName );
+			this.markViewer( viewerName );
 		} );
 
 		return ret;
+	}
+
+	/**
+	 * Marks given viewer as a selected one.
+	 *
+	 * @param {string} viewerName
+	 */
+	markViewer( viewerName ) {
+		this._elem.querySelectorAll( '.btn-primary' ).forEach( el => el.classList.remove( 'btn-primary' ) );
+
+		if ( viewerName ) {
+			let res = this._elem.querySelector( `[data-viewer-name="${viewerName}"]` );
+			if ( res ) {
+				res.classList.add( 'btn-primary' );
+			}
+		}
 	}
 
 	_clear() {

--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -1,0 +1,30 @@
+
+'use strict';
+
+/**
+ * Abstract base class for editors used to modify supported content types.
+ */
+class Editor {
+	/**
+	 * Commits edited value to the given clipboard data type.
+	 *
+	 * @returns {Promise.<Buffer>}
+	 */
+	async save() {
+	}
+
+	/**
+	 * Shows the editor (and adds it to the DOM if necessary).
+	 *
+	 * @param {ClipboardSnapshot} item Clipboard item that the editor is shown for.
+	 * @param {string} type Clipboard type to be edit.
+	 */
+	async show( _item, _type ) {}
+
+	/**
+	 * Hides the editor. It also reverts the value back to the original one if necessary.
+	 */
+	async hide() {}
+}
+
+module.exports = Editor;

--- a/src/Editor/Html.js
+++ b/src/Editor/Html.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const Editor = require( './Editor' ),
+	utf8decoder = new TextDecoder( 'utf8' ),
+	path = require( 'path' );
+
+class Html extends Editor {
+	/**
+	 * Commits edited value to the given clipboard data type.
+	 *
+	 * @returns {Promise.<Buffer>}
+	 */
+	async save( item, type ) {
+		if ( this._editor ) {
+			item.setValue( type, Buffer.from( this._editor.getValue(), 'utf8' ) );
+		}
+
+		await this.hide();
+	}
+
+	async show( item, type ) {
+		let monaco = await this._getMonaco(),
+			wrapper = document.getElementById( 'editor' ),
+			string = utf8decoder.decode( item.getValue( type ) );
+
+		wrapper.innerHTML = '<div id="monaco-editor"></div>';
+
+		let editor = monaco.editor.create( document.getElementById( 'monaco-editor' ), {
+			value: string,
+			language: 'html',
+			theme: global.app.config.monacoTheme,
+			minimap: {
+				enabled: false
+			}
+		} );
+
+		this._editor = editor;
+
+		editor.focus();
+	}
+
+	/**
+	 * Hides the editor. It also reverts the value back to the original one if necessary.
+	 */
+	async hide() {
+		if ( this._editor ) {
+			this._editor.dispose();
+			this._editor = null;
+		}
+	}
+
+	/**
+	 * Encapsulates all the [Monaco](https://github.com/Microsoft/monaco-editor) loading stuff.
+	 *
+	 * @returns {Promise.<monaco>} See https://microsoft.github.io/monaco-editor/api/index.html for a reference.
+	 */
+	async _getMonaco() {
+		// Code is heavily based on:
+		// https://github.com/Microsoft/monaco-editor-samples/blob/4ce21071528f9b6f898975ff35730e6833552623/sample-electron/index.html
+		let nodeRequire = global.require,
+			editorPrototype = Object.getPrototypeOf( this ),
+			amdRequire = editorPrototype._amdRequire;
+
+		if ( !amdRequire ) {
+			// Monaco is being loaded for the first time.
+			let monacoLoader = require( '../../node_modules/monaco-editor/min/vs/loader.js' );
+
+			// amdRequire = global.require;
+			amdRequire = monacoLoader.require;
+			global.require = nodeRequire;
+
+			function uriFromPath( _path ) {
+				var pathName = path.resolve( _path ).replace( /\\/g, '/' );
+				if ( pathName.length > 0 && pathName.charAt( 0 ) !== '/' ) {
+					pathName = '/' + pathName;
+				}
+				return encodeURI( 'file://' + pathName );
+			}
+			amdRequire.config( {
+				baseUrl: uriFromPath( path.join( __dirname, '..', '../node_modules/monaco-editor/min' ) )
+			} );
+
+			// workaround monaco-css not understanding the environment
+			self.module = undefined;
+			// workaround monaco-typescript not understanding the environment
+			self.process.browser = true;
+
+			editorPrototype._amdRequire = amdRequire;
+		}
+
+		return new Promise( function( resolve ) {
+			amdRequire( [ 'vs/editor/editor.main' ], function() {
+				resolve( global.monaco );
+			} );
+		} );
+	}
+}
+
+module.exports = Html;

--- a/src/Editor/Text.js
+++ b/src/Editor/Text.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const Editor = require( './Editor' ),
+	utf8decoder = new TextDecoder( 'utf8' ),
+	utf16decoder = new TextDecoder( 'utf-16le' );
+
+class Text extends Editor {
+	/**
+	 * Commits edited value to the given clipboard data type.
+	 *
+	 * @returns {Promise.<Buffer>}
+	 */
+	async save( item, type ) {
+		let textarea = this._getTextarea(),
+			val = textarea && textarea.value;
+
+		if ( typeof val !== 'string' ) {
+			console.warn( 'Could not pick new text value' );
+		} else {
+			let isWinClipboard = item.env.name == 'win32',
+				targetEncoding = 'utf8';
+
+			if ( isWinClipboard && type === 'CF_UNICODETEXT' ) {
+				targetEncoding = 'utf-16le';
+			}
+
+			item.setValue( type, Buffer.from( val, targetEncoding ) );
+		}
+
+		await this.hide();
+	}
+
+	async show( item, type ) {
+		let bytes = item.getValue( type ),
+			isWinClipboard = item.env.name == 'win32',
+			decoder = ( isWinClipboard && type === 'CF_UNICODETEXT' ) ? utf16decoder : utf8decoder,
+			string = decoder.decode( bytes ),
+			textarea = this._getTextarea();
+
+		if ( isWinClipboard && string[ string.length - 1 ] === '\0' ) {
+			// Windows always adds NULL byte char at the end.
+			string = string.slice( 0, -1 );
+		}
+
+		if ( !textarea ) {
+			textarea = document.createElement( 'textarea' );
+			textarea.classList = 'text-editor';
+			document.getElementById( 'editor' ).prepend( textarea );
+		}
+
+		textarea.value = string;
+
+		textarea.focus();
+	}
+
+	/**
+	 * Hides the editor. It also reverts the value back to the original one if necessary.
+	 */
+	async hide() {
+		let textarea = this._getTextarea();
+
+		if ( textarea ) {
+			textarea.remove();
+		}
+	}
+
+	/**
+	 * Returns the textarea element if present.
+	 *
+	 * @returns {HTMLTextareaElement/null}
+	 */
+	_getTextarea() {
+		return document.querySelector( '#editor textarea.text-editor' );
+	}
+}
+
+module.exports = Text;

--- a/src/MainWindowController.js
+++ b/src/MainWindowController.js
@@ -32,6 +32,8 @@ class MainWindowController {
 
 		if ( viewerName && this.viewers[ viewerName ] ) {
 			viewer = this.viewers[ viewerName ];
+		} else  {
+			viewerName = this._getViewerName( viewer );
 		}
 
 		this._showContainers( [ 'render', 'previewMenu' ] );
@@ -40,6 +42,7 @@ class MainWindowController {
 
 		prev.innerHTML = '';
 		viewer.display( item, previewType, prev );
+		this.app.previews.markViewer( viewerName );
 
 		this._appendEditorUi( item, previewType, viewer );
 	}
@@ -102,7 +105,8 @@ class MainWindowController {
 	 */
 	async _appendEditorUi( item, type, viewer ) {
 		let editor = viewer.getEditor(),
-			editorButton = document.querySelector( '#previewOptions .edit-btn' );
+			editorButton = document.querySelector( '#previewOptions .edit-btn' ),
+			viewerName = Object.keys( this.viewers ).filter( viewerKey => this.viewers[ viewerKey ] === viewer )[ 0 ];
 
 		const activeCssClass = 'btn-info';
 
@@ -126,7 +130,7 @@ class MainWindowController {
 					editorButton.classList.remove( activeCssClass );
 					await editor.save( item, type );
 					// Committing edit value.
-					this.previewItem( item, type );
+					this.previewItem( item, type, viewerName );
 				}
 			};
 
@@ -137,6 +141,14 @@ class MainWindowController {
 			editorButton.classList.add( 'hidden' );
 			editorButton.classList.remove( activeCssClass );
 		}
+	}
+
+	/**
+	 * @param {Viewer} viewer
+	 * @returns {string/undefined} Key in {@link _viewers} of a given `viewer`.
+	 */
+	_getViewerName( viewer ) {
+		return Object.keys( this.viewers ).filter( viewerKey => this.viewers[ viewerKey ] === viewer )[ 0 ];
 	}
 }
 

--- a/src/MainWindowController.js
+++ b/src/MainWindowController.js
@@ -34,12 +34,34 @@ class MainWindowController {
 			viewer = this.viewers[ viewerName ];
 		}
 
-		this._showContainers( [ 'render', 'previewTypes' ] );
+		this._showContainers( [ 'render', 'previewMenu' ] );
 
 		this.app.previews.update( this.viewers, item, previewType );
 
 		prev.innerHTML = '';
 		viewer.display( item, previewType, prev );
+
+		this._appendEditorUi( item, previewType, viewer );
+	}
+
+	/**
+	 * Shows the edit component for a given `item`.
+	 *
+	 * @param {ClipboardSnapshot} item Snapshot to be edited.
+	 * @param {string} type
+	 * @param {Editor} editor
+	 * @returns {Promise} Promise is resolved as edit view is displayed and ready.
+	 */
+	async editItem( item, type, editor ) {
+		if ( !item ) {
+			item = this.app.snapshots.getSelected();
+		}
+
+		if ( item ) {
+			this._showContainers( [ 'previewMenu', 'editor' ] );
+
+			await editor.show( item, type );
+		}
 	}
 
 	/**
@@ -60,13 +82,60 @@ class MainWindowController {
 	 * @param {string[]} containers Id of HTML containers to be shown. All others will be hidden.
 	 */
 	_showContainers( containers ) {
-		const allContainers = [ 'previewTypes', 'content', 'render' ];
+		const allContainers = [ 'previewMenu', 'editor', 'content', 'render' ];
 
 		for ( let id of allContainers ) {
 			let elem = document.getElementById( id );
 			if ( elem ) {
 				elem.style.display = containers.includes( id ) ? null : 'none';
 			}
+		}
+	}
+
+	/**
+	 * Appends editor for a given clipboard item.
+	 *
+	 * @private
+	 * @param {ClipboardSnapshot} item
+	 * @param {string} type Clipboard type previewed, e.g. `'HTML Format'`,  `'CF_UNICODE'` etc.
+	 * @param {Viewer} viewer
+	 */
+	async _appendEditorUi( item, type, viewer ) {
+		let editor = viewer.getEditor(),
+			editorButton = document.querySelector( '#previewOptions .edit-btn' );
+
+		const activeCssClass = 'btn-info';
+
+		// In any case remove previous listener.
+		editorButton.removeEventListener( 'click', this._editCallback );
+
+		if ( this._lastEditor ) {
+			await this._lastEditor.hide();
+			this._lastEditor = null;
+		}
+
+		if ( editor ) {
+			editorButton.classList.remove( 'hidden' );
+
+			this._editCallback = async() => {
+				if ( !editorButton.classList.contains( activeCssClass ) ) {
+					editorButton.classList.add( activeCssClass );
+
+					this.editItem( item, type, editor );
+				} else {
+					editorButton.classList.remove( activeCssClass );
+					await editor.save( item, type );
+					// Committing edit value.
+					this.previewItem( item, type );
+				}
+			};
+
+			this._lastEditor = editor;
+
+			editorButton.addEventListener( 'click', this._editCallback );
+		} else {
+			editorButton.classList.add( 'hidden' );
+			editorButton.classList.remove( activeCssClass );
 		}
 	}
 }

--- a/src/Viewer/Html/Render.js
+++ b/src/Viewer/Html/Render.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Viewer = require( '../Viewer' ),
+	HtmlEditor = require( '../../Editor/Html' ),
 	utf8decoder = new TextDecoder( 'utf8' );
 
 class Text extends Viewer {
@@ -17,6 +18,14 @@ class Text extends Viewer {
 	 */
 	handles( type ) {
 		return type.toLowerCase().indexOf( 'html' ) !== -1;
+	}
+
+	getEditor( _type ) {
+		if ( !this._editor ) {
+			this._editor = new HtmlEditor();
+		}
+
+		return this._editor;
 	}
 
 	/**

--- a/src/Viewer/Text.js
+++ b/src/Viewer/Text.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Viewer = require( './Viewer' ),
+	TextEditor = require( '../Editor/Text' ),
 	utf8decoder = new TextDecoder( 'utf8' ),
 	utf16decoder = new TextDecoder( 'utf-16le' );
 
@@ -19,6 +20,14 @@ class Text extends Viewer {
 	handles() {
 		// For now let's assume that it handles everything.
 		return true;
+	}
+
+	getEditor( _type ) {
+		if ( !this._editor ) {
+			this._editor = new TextEditor();
+		}
+
+		return this._editor;
 	}
 
 	/**

--- a/src/Viewer/Viewer.js
+++ b/src/Viewer/Viewer.js
@@ -22,6 +22,16 @@ class Viewer {
 	}
 
 	/**
+	 * This method is used to return editor interface for a given type.
+	 *
+	 * @param {string} _type Content type.
+	 * @returns {ViewerEditor/null} `null` if not available.
+	 */
+	getEditor( _type ) {
+		return null;
+	}
+
+	/**
 	 * This method implements rendering.
 	 *
 	 * @param {ClipboardSnapshot} item

--- a/tests/ClipboardSnapshot.test.js
+++ b/tests/ClipboardSnapshot.test.js
@@ -2,6 +2,60 @@ const ClipboardSnapshotMock = require( './mock/ClipboardSnapshotMock' ),
 	ClipboardSnapshot = require( '../src/ClipboardSnapshot' );
 
 describe( 'ClipboardSnapshot', () => {
+	describe( 'setValue()', () => {
+		let mock;
+
+		beforeEach( () => {
+			mock = new ClipboardSnapshotMock( {
+				aa: Buffer.from( [ 64, 65 ] ),
+				bb: Buffer.from( [ 64, 65 ] )
+			} );
+		} );
+
+		it( 'Changes the data', () => {
+			mock.setValue( 'bb', Buffer.from( [ 68, 68 ] ) );
+
+			expect( mock._content.get( 'bb' ) ).to.be.eql( Buffer.from( [ 68, 68 ] ) );
+		} );
+
+		it( 'Works with Uint8Array', () => {
+			mock.setValue( 'bb', new Uint8Array( [ 76 ] ) );
+
+			expect( mock._content.get( 'bb' ) ).to.be.eql( new Uint8Array( [ 76 ] ) );
+		} );
+
+		it( 'Fires changed event', () => {
+			let changedListener = sinon.spy();
+
+			mock.on( 'changed', changedListener );
+			mock.setValue( 'bb', Buffer.from( [ 68, 68 ] ) );
+
+			expect( changedListener ).to.be.calledOnce;
+		} );
+
+		it( 'Doesnt fire changed event if the data is the same', () => {
+			let changedListener = sinon.spy();
+
+			mock.on( 'changed', changedListener );
+			mock.setValue( 'aa', Buffer.from( [ 64, 65 ] ) );
+
+			expect( changedListener ).not.to.be.called;
+		} );
+
+		describe( 'Error handling', () => {
+			before( () => sinon.stub( console, 'error' ) );
+			after( () => console.error.restore() );
+
+			it( 'Reports an error in case of invalid value', () => {
+				mock.setValue( 'bb', undefined );
+
+				// expect( mock._content.get( 'bb' ) ).to.be.eql( Buffer.from( [ 68, 68 ] ) );
+				expect( console.error ).to.be.calledOnce;
+				expect( console.error ).to.be.calledWithExactly( 'ClipboardSnapshot.setValue() invalid argument, expected buffer while undefined was given.' );
+			} );
+		} );
+	} );
+
 	describe( 'createFromData', () => {
 		let sampleData = {
 				meta: {

--- a/tests/ClipboardSnapshot.test.js
+++ b/tests/ClipboardSnapshot.test.js
@@ -42,6 +42,14 @@ describe( 'ClipboardSnapshot', () => {
 			expect( changedListener ).not.to.be.called;
 		} );
 
+		it( 'Bails out hashes', () => {
+			mock._hashesCached = 1;
+
+			mock.setValue( 'bb', Buffer.from( [ 72 ] ) );
+
+			expect( mock._hashesCached ).to.be.null;
+		} );
+
 		describe( 'Error handling', () => {
 			before( () => sinon.stub( console, 'error' ) );
 			after( () => console.error.restore() );


### PR DESCRIPTION
This PR introduces editors. This feature gives ability to edit given clipboard type (ofc it edits one type at a time).

![Edit button in MrClippy](https://i.imgur.com/S7qnxgG.png)

I decided to put two editors at the beginning:

* Text - just plain text textarea.
* HTML - integrated Monaco editor.

	![Editing HTML in MrClippy with Monaco editor](https://i.imgur.com/3FrYdlS.png)

All in all it was great that I was able to already integrate HTML editor, though both editors need some UX anc styling tweaks - but I don't want to put more time on it at this point.

Unfortunately this introduced quite a bit of technical debt, as few bits are programmed in a way that I'm not happy with it. I'll get back to it at some point.

Closes #44.