### PR TITLE
Add basic support for Mac and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,24 @@ A simple, experimental app for storing, editing and loading clipboard content.
 
 The app is under heavy development to define its initial shape. At this point I don't care that much for UI until all the essential features are in place.
 
-Initially the app is developed on Windows. [Mac](https://github.com/mlewand/mrclippy/issues/21) and [Linux](https://github.com/mlewand/mrclippy/issues/20) support will follow shortly after.
+Initially the app was developed on Windows. Now it has a basic support on [Mac](https://github.com/mlewand/mrclippy/issues/21) and [Linux](https://github.com/mlewand/mrclippy/issues/20), but I'd like to have a full (see [#53](https://github.com/mlewand/mrclippy/issues/53) for more details, contributors are welcome).
 
 Contributions are welcome.
 
-## Requirements
+## Dev Requirements
 
 * nodejs
 
-Dev version (Windows):
+## Windows
 
-* `npm install --global --production windows-build-tools` - ran as Administrator
+* `npm install --global --production windows-build-tools` - run as Administrator
+
+### Linux
+
+Below requirements are based on Ubuntu 17:
+
+* `sudo apt install make`
+* `sudo apt-get install libgconf-2-4` - [required by Electron](https://github.com/electron/electron/issues/1518)
 
 ## Running the app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1481,7 +1481,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "immediate": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "electron-debug": "^1.4.0",
     "electron-rebuild": "^1.5.7",
     "fs-extra": "^4.0.2",
+    "iconv-lite": "^0.4.19",
     "is-buffer": "^1.1.6",
     "jszip": "^3.1.5",
     "localforage": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
     "jszip": "^3.1.5",
     "localforage": "^1.5.5",
     "pad": "^1.1.0",
-    "sanitize-filename": "^1.6.1",
-    "win-clipboard": "^0.0.5"
+    "sanitize-filename": "^1.6.1"
+  },
+  "optionalDependencies": {
+    "win-clipboard": "^0.0.6"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/src/ClipboardSnapshot.js
+++ b/src/ClipboardSnapshot.js
@@ -7,10 +7,7 @@
 		OsEnvironment = require( './OsEnvironment' ),
 		crc32 = require( 'crc-32' ),
 		deepEql = require( 'deep-eql' ),
-		isBufferBase = require( 'is-buffer' ),
-		isBuffer = function( buffer ) {
-			return isBufferBase( buffer ) || buffer instanceof Object.getPrototypeOf( Int8Array );
-		};
+		isBuffer = require( './utils' ).isBuffer;
 
 	class ClipboardSnapshot extends EventEmitter {
 		/**

--- a/src/ClipboardSnapshot.js
+++ b/src/ClipboardSnapshot.js
@@ -109,7 +109,7 @@
 			} ) );
 
 			// Determine the label.
-			if ( typeof textValue == 'string' ) {
+			if ( typeof textValue == 'string' && textValue.length ) {
 				label = textValue.trim();
 			}
 

--- a/src/Reader/Reader.js
+++ b/src/Reader/Reader.js
@@ -1,3 +1,6 @@
+const iconv = require( 'iconv-lite' ),
+	isBuffer = require( '../utils' ).isBuffer;
+
 /**
  * Reader is a helper type that can read from ClipboardSnapshot instance, adjusting to the way how OS stores the clipboard.
  */
@@ -10,7 +13,15 @@ class Reader {
 	 */
 	readText( snapshot, type ) {
 		// By default all the OS that uses Electron clipboard API stores strings (except for stuff like images).
-		return snapshot.getValue( type );
+		let ret = snapshot.getValue( type );
+
+		// But images due to our custom logic images are returned as blob (since Electron operates on NativeImage).
+		if ( type.startsWith( 'image/' ) && isBuffer( ret ) ) {
+			// Treat images as encoded with ASCII.
+			ret = iconv.decode( Buffer.from( ret ), 'ascii' );
+		}
+
+		return ret;
 	}
 
 	static getReaderFor( snapshot ) {

--- a/src/Reader/Reader.js
+++ b/src/Reader/Reader.js
@@ -17,8 +17,7 @@ class Reader {
 
 		// But images due to our custom logic images are returned as blob (since Electron operates on NativeImage).
 		if ( type.startsWith( 'image/' ) && isBuffer( ret ) ) {
-			// Treat images as encoded with ASCII.
-			ret = iconv.decode( Buffer.from( ret ), 'ascii' );
+			ret = iconv.decode( Buffer.from( ret ), 'utf8' );
 		}
 
 		return ret;

--- a/src/Reader/Reader.js
+++ b/src/Reader/Reader.js
@@ -1,0 +1,27 @@
+/**
+ * Reader is a helper type that can read from ClipboardSnapshot instance, adjusting to the way how OS stores the clipboard.
+ */
+class Reader {
+	/**
+	 *
+	 * @param {ClipboardSnapshot} snapshot
+	 * @param {string} type
+	 * @returns {string}
+	 */
+	readText( snapshot, type ) {
+		// By default all the OS that uses Electron clipboard API stores strings (except for stuff like images).
+		return snapshot.getValue( type );
+	}
+
+	static getReaderFor( snapshot ) {
+		const Win = require( './Win' );
+
+		if ( snapshot.env.name == 'win32' ) {
+			return new Win();
+		}
+
+		return new Reader();
+	}
+}
+
+module.exports = Reader;

--- a/src/Reader/Win.js
+++ b/src/Reader/Win.js
@@ -1,0 +1,40 @@
+const iconv = require( 'iconv-lite' ),
+	Reader = require( './Reader.js' );
+
+class WinReader extends Reader {
+	/**
+	 *
+	 * @param {ClipboardSnapshot} snapshot
+	 * @param {string} [type='CF_UNICODETEXT']
+	 * @returns {string}
+	 */
+	readText( snapshot, type ) {
+		let encoding = 'utf8',
+			val = snapshot.getValue( type ),
+			ret;
+
+		type = type || 'CF_UNICODETEXT';
+
+		if ( [ 'CF_UNICODETEXT', 'CF_TEXT' ].includes( type ) ) {
+			encoding = 'utf-16le';
+		}
+
+		ret = iconv.decode( Buffer.from( val ), encoding );
+
+		if ( ret[ ret.length - 1 ] === '\0' ) {
+			// Windows always adds NULL byte char at the end.
+			// @todo: this should be handled in the clipboard lib.
+			let nullBytesCount = 1;
+
+			if ( encoding === 'utf-16le' && ret[ ret.length - 2 ] == 0 ) {
+				nullBytesCount = 2;
+			}
+
+			ret = ret.slice( 0, nullBytesCount * -1 );
+		}
+
+		return ret;
+	}
+}
+
+module.exports = WinReader;

--- a/src/Viewer/Hex.js
+++ b/src/Viewer/Hex.js
@@ -32,6 +32,10 @@ class Hex extends Viewer {
 			html = '',
 			i;
 
+		if ( typeof value == 'string' ) {
+			value = Buffer.from( value, 'utf8' );
+		}
+
 		for ( i = 0; i < value.length; i++ ) {
 			let byte = value[ i ];
 

--- a/src/Viewer/Html/Render.js
+++ b/src/Viewer/Html/Render.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Viewer = require( '../Viewer' ),
-	utf8decoder = new TextDecoder( 'utf8' );
+	Reader = require( '../../Reader/Reader' );
 
 class Text extends Viewer {
 	constructor() {
@@ -27,7 +27,8 @@ class Text extends Viewer {
 	 * @param {HTMLElement} element A wrapper element where the content preview have to be rendered.
 	 */
 	display( item, type, element ) {
-		let html = utf8decoder.decode( item.getValue( type ) );
+		let reader = Reader.getReaderFor( item ),
+			html = reader.readText( item, type );
 
 		// For Windows, the display value needs to be further sanitized.
 		if ( process.platform == 'win32' ) {

--- a/src/Viewer/Text.js
+++ b/src/Viewer/Text.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const Viewer = require( './Viewer' ),
-	utf8decoder = new TextDecoder( 'utf8' ),
-	utf16decoder = new TextDecoder( 'utf-16le' );
+	Reader = require( '../Reader/Reader' );
 
 class Text extends Viewer {
 	constructor() {
@@ -29,17 +28,9 @@ class Text extends Viewer {
 	 * @param {HTMLElement} element A wrapper element where the content preview have to be rendered.
 	 */
 	display( item, type, element ) {
-		let bytes = item.getValue( type ),
-			isWinClipboard = item.env.name == 'win32',
-			decoder = ( isWinClipboard && type === 'CF_UNICODETEXT' ) ? utf16decoder : utf8decoder,
-			string = decoder.decode( bytes );
+		let reader = Reader.getReaderFor( item );
 
-		if ( isWinClipboard && string[ string.length - 1 ] === '\0' ) {
-			// Windows always adds NULL byte char at the end.
-			string = string.slice( 0, -1 );
-		}
-
-		element.innerText = string;
+		element.innerText = reader.readText( item, type );
 	}
 }
 

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -21,5 +21,59 @@ module.exports = Object.assign( {}, clip, {
 		for ( let [ type, data ] of snapshot._content ) {
 			this.write( type, data );
 		}
+	},
+
+	/**
+	 * Read method had to be overwritten, due to reasons described in {@link #_getElectronClipboardGetter}.
+	 *
+	 * @param {string} type
+	 * @returns {mixed}
+	 */
+	read( type ) {
+		let readFunction = this._getElectronClipboardGetter( type );
+
+		if ( readFunction ) {
+			console.log( 'reading', type );
+			return this[ readFunction ]( type );
+		}
+
+		return null;
+	},
+
+	/**
+	 * At the time of writing there's a rather big annoyance in Electron clipboard API. The problem is that in order to get any interesting
+	 * type/value you need to call a different method for any clipboard type.
+	 *
+	 * For instance, if you want to get `'text/html'` value you must call `clipboard.readHTML( 'text/html' )`. You can't call `clipboard.readText( 'text/html' )`
+	 * it will return empty string.
+	 *
+	 * Ideally I'd love to call `clipboard.readBuffer( type )` which should return `Buffer` instance containing raw data, but it's only working with **native
+	 * formats**. So you should pass `'HTML Format'` on Windows, instead of `'text/html'` and **there is no method** to enumerate native types. The only method
+	 * `clipboard.availableFormats()` returns "decorated" types, so `'text/html'` instead of `'HTML Format'`; `'text/plain'` instead of `'CF_UNICODETEXT'`.
+	 *
+	 * @private
+	 * @returns {string} type "Decorated" electron clipboard format, like `'text/html'`.
+	 * @returns {string/null} Read method name, like `'readHTML'`, `'readText'` or `null` if no matching type is known.
+	 */
+	_getElectronClipboardGetter( type ) {
+		type = String( type );
+
+		if ( type == 'text/html' ) {
+			return 'readHTML';
+		}
+
+		if ( type == 'text/rtf' ) {
+			return 'readRTF';
+		}
+
+		if ( String( type ).startsWith( 'image/' ) ) {
+			return 'readImage';
+		}
+
+		if ( String( type ).startsWith( 'text/' ) ) {
+			return 'readText';
+		}
+
+		return null;
 	}
 } );

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -2,16 +2,14 @@
 
 const nativeImage = require( 'electron' ).nativeImage;
 
-let clip;
+let clip = {};
 
 if ( process.platform == 'win32' ) {
 	clip = require( './clipboard.win32' );
-} else {
-	clip = require( 'electron' ).clipboard;
 }
 
 // Extend returned object, to be ure not to overwrite Electron clipboard object.
-module.exports = Object.assign( {}, clip, {
+module.exports = Object.assign( {}, require( 'electron' ).clipboard, {
 	/**
 	 * Writes provided snapshot to the current OS clipboard.
 	 *
@@ -109,4 +107,4 @@ module.exports = Object.assign( {}, clip, {
 
 		return null;
 	}
-} );
+}, clip );

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -33,7 +33,6 @@ module.exports = Object.assign( {}, clip, {
 		let readFunction = this._getElectronClipboardGetter( type );
 
 		if ( readFunction ) {
-			console.log( 'reading', type );
 			return this[ readFunction ]( type );
 		}
 

--- a/src/clipboard.win32.js
+++ b/src/clipboard.win32.js
@@ -6,6 +6,19 @@ module.exports = {
 	availableFormats: () => winClipboard.getFormats(),
 
 	/**
+	 * Writes provided snapshot to the current OS clipboard.
+	 *
+	 * @param {ClipboardSnapshot} snapshot
+	 */
+	writeSnapshot( snapshot ) {
+		this.clear();
+
+		for ( let [ type, data ] of snapshot._content ) {
+			this.write( type, data );
+		}
+	},
+
+	/**
 	 * Reads `type` value from current OS clipboard.
 	 *
 	 * @param {string} type

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,12 @@
+
+const isBufferBase = require( 'is-buffer' );
+
+module.exports = {
+	/**
+	 * @param {mixed} buffer Returns `true` if given argument is a Buffer or Int8Array instance.
+	 * @returns {boolean}
+	 */
+	isBuffer( buffer ) {
+		return isBufferBase( buffer ) || buffer instanceof Object.getPrototypeOf( Int8Array );
+	}
+};


### PR DESCRIPTION
This PR brings very basic support for Mac and Linux.

Unfortunately due to [Electron clipboard](https://github.com/electron/electron/blob/master/docs/api/clipboard.md) API it's impossible to do a serious clipboard handling.

In addition to that it forced me to do tens of hacks/tweaks.

For now it works only with types supported by default by Electron so types like:

* `text/plain`
* `text/html`
* `text/rtf`
* `image/png`

I did a quick search for a Node package that would solve this issue, but all the clipboard libraries are super simple, limited to putting text/HTML - so essentially same thing that is exposed by Electron API.

In terms of Linux support I tested it on Ubuntu 17.

Closes #20, closes #21.